### PR TITLE
Added milliseconds if field_type is Time

### DIFF
--- a/lib/mongoid/criterion/scrollable.rb
+++ b/lib/mongoid/criterion/scrollable.rb
@@ -19,7 +19,8 @@ module Mongoid
         cursor = cursor.is_a?(Mongoid::Scroll::Cursor) ? cursor : Mongoid::Scroll::Cursor.new(cursor, cursor_options)
         # scroll
         if block_given?
-          criteria.where(cursor.criteria).order_by(_id: scroll_direction).each do |record|
+          #FIXME: I've taken out 'order_by(_id: scroll_direction)' after where... in order to avoid more fields on index (not necessary).
+          criteria.where(cursor.criteria).each do |record|
             yield record, Mongoid::Scroll::Cursor.from_record(record, cursor_options)
           end
         else

--- a/lib/mongoid/criterion/scrollable.rb
+++ b/lib/mongoid/criterion/scrollable.rb
@@ -20,7 +20,7 @@ module Mongoid
         # scroll
         if block_given?
           #FIXME: I've taken out 'order_by(_id: scroll_direction)' after where... in order to avoid more fields on index (not necessary).
-          criteria.where(cursor.criteria).each do |record|
+          criteria.where(cursor.criteria).order_by(_id: scroll_direction).each do |record|
             yield record, Mongoid::Scroll::Cursor.from_record(record, cursor_options)
           end
         else

--- a/lib/mongoid/scroll/cursor.rb
+++ b/lib/mongoid/scroll/cursor.rb
@@ -65,7 +65,7 @@ module Mongoid
           when 'BSON::ObjectId', 'Moped::BSON::ObjectId' then value
           when 'String' then value.to_s
           when 'DateTime' then value.is_a?(DateTime) ? value : Time.at(value.to_i).to_datetime
-          when 'Time' then value.is_a?(Time) ? value : Time.at(value.to_i)
+          when 'Time' then value.is_a?(Time) ? value : Time.at(value.to_f)
           when 'Date' then value.is_a?(Date) ? value : Time.at(value.to_i).utc.to_date
           when 'Float' then value.to_f
           when 'Integer' then value.to_i
@@ -79,13 +79,20 @@ module Mongoid
           when 'BSON::ObjectId', 'Moped::BSON::ObjectId' then value
           when 'String' then value.to_s
           when 'Date' then Time.utc(value.year, value.month, value.day).to_i
-          when 'DateTime', 'Time' then value.to_i
+          when 'DateTime', 'Time' then add_msec_to_time(value)
           when 'Float' then value.to_f
           when 'Integer' then value.to_i
           else
             raise Mongoid::Scroll::Errors::UnsupportedFieldTypeError.new(field: field_name, type: field_type)
           end
         end
+
+        def add_msec_to_time(value)
+          milliseconds = value.usec/1000
+          time_w_millsecs_string = value.to_i.to_s+"."+milliseconds.to_s
+          time_w_millsecs_string.to_f
+        end
+        
       end
     end
   end

--- a/lib/mongoid/scroll/cursor.rb
+++ b/lib/mongoid/scroll/cursor.rb
@@ -79,7 +79,8 @@ module Mongoid
           when 'BSON::ObjectId', 'Moped::BSON::ObjectId' then value
           when 'String' then value.to_s
           when 'Date' then Time.utc(value.year, value.month, value.day).to_i
-          when 'DateTime', 'Time' then add_msec_to_time(value)
+          when 'DateTime' then value.to_time.to_f
+          when 'Time' then value.to_f
           when 'Float' then value.to_f
           when 'Integer' then value.to_i
           else


### PR DESCRIPTION
Using :created_at as 'field_name'.

`Item.desc(:created_at).limit(IMOS_PER_PAGE).scroll(current_cursor) do |item, cursor|`

My items are created very fast and I have several of them created at the same second. The cursor just contemplated seconds and whenever a new cursor was passed, it went straight at the next second. Now it takes milliseconds in :created_at. It is more accurate. 
