### PR TITLE
Demonstrate (and fix?) problem scrolling by foreign key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,5 @@ matrix:
         - bundle exec danger
 
 bundler_args: --without development
+
+dist: precise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,45 @@
-0.3.6 (Next)
-------------
+### 0.3.6 (Next)
 
+* [#14](https://github.com/mongoid/mongoid-scroll/pull/14): Allow scrolling by foreign key - [@joeyAghion](https://github.com/joeyAghion).
 * Your contribution here.
 
-0.3.5 (2016/09/27)
-------------------
+### 0.3.5 (2016/09/27)
 
 * [#11](https://github.com/mongoid/mongoid-scroll/pull/11): Compatibility with Mongoid 6 - [@dblock](https://github.com/dblock).
 * [#12](https://github.com/mongoid/mongoid-scroll/pull/12): Added Danger, PR linter - [@dblock](https://github.com/dblock).
 
-0.3.4 (2015/10/22)
-------------------
+### 0.3.4 (2015/10/22)
 
 * Added support for [mongo-ruby-driver](https://github.com/mongodb/mongo-ruby-driver), `Mongo::Collection::View` - [@dblock](https://github.com/dblock).
 
-0.3.3 (2015/09/17)
-------------------
+### 0.3.3 (2015/09/17)
 
 * Compatibility with Mongoid 5 - [@dblock](https://github.com/dblock).
 
-0.3.2 (2015/8/8)
-----------------
+### 0.3.2 (2015/8/8)
 
 * [#7](https://github.com/mongoid/mongoid-scroll/pull/7): Fix: pre-merge cursor criteria fields - [@sweir27](https://github.com/sweir27).
 
-0.3.1 (2015/7/27)
------------------
+### 0.3.1 (2015/7/27)
 
 * Compatibility with Mongoid 5.x beta - [@dblock](https://github.com/dblock).
 * [#4](https://github.com/mongoid/mongoid-scroll/pull/4): Fix: support chaining `$or` criteria - [@sweir27](https://github.com/sweir27).
 * [#5](https://github.com/mongoid/mongoid-scroll/pull/5): Fix: embeddable objects now returned in pagination - [@sweir27](https://github.com/sweir27).
 
-0.3.0 (2014/1/7)
-----------------
+### 0.3.0 (2014/1/7)
 
 * Compatibility with Mongoid 4.x - [@dblock](https://github.com/dblock).
 * Implemeneted Rubocop, Ruby linter - [@dblock](https://github.com/dblock).
 
-0.2.1 (2013/3/21)
------------------
+### 0.2.1 (2013/3/21)
 
 * Fix: scroll over a collection that has duplicate values while data is being modified in a way that causes a change in the natural sort order - [@dblock](https://github.com/dblock).
 
-0.2.0 (2013/3/14)
------------------
+### 0.2.0 (2013/3/14)
 
 * Extended `Moped::Query` with `scroll` - [@dblock](https://github.com/dblock).
 * `Mongoid::Scroll::Cursor.from_record` can now be called with either a Mongoid field or `field_type` and `field_name` in the `options` hash - [@dblock](https://github.com/dblock).
 
-0.1.0 (2013/2/14)
------------------
+### 0.1.0 (2013/2/14)
 
 * Initial public release, extends `Mongoid::Criteria` with `scroll` - [@dblock](https://github.com/dblock).
-

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gemspec
 case version = ENV['MONGOID_VERSION'] || '~> 6.0'
 when 'HEAD'
   gem 'mongoid', github: 'mongodb/mongoid'
+when /7/
+  gem 'mongoid', github: 'mongodb/mongoid', branch: '7.0-dev'
 when /6/
   gem 'mongoid', '~> 6.0'
 when /5/

--- a/lib/mongoid/criterion/scrollable.rb
+++ b/lib/mongoid/criterion/scrollable.rb
@@ -30,7 +30,8 @@ module Mongoid
       end
 
       def type_from_field(field)
-        field.foreign_key? && field.object_id_field? ? BSON::ObjectId : field.type
+        bson_type = Mongoid::Compatibility::Version.mongoid3? ? Moped::BSON::ObjectId : BSON::ObjectId
+        field.foreign_key? && field.object_id_field? ? bson_type : field.type
       end
     end
   end

--- a/lib/mongoid/criterion/scrollable.rb
+++ b/lib/mongoid/criterion/scrollable.rb
@@ -15,7 +15,7 @@ module Mongoid
         scroll_direction = criteria.options[:sort].values.first.to_i
         # scroll cursor from the parameter, with value and tiebreak_id
         field = criteria.klass.fields[scroll_field.to_s]
-        cursor_options = { field_type: field.type, field_name: scroll_field, direction: scroll_direction }
+        cursor_options = { field_type: type_from_field(field), field_name: scroll_field, direction: scroll_direction }
         cursor = cursor.is_a?(Mongoid::Scroll::Cursor) ? cursor : Mongoid::Scroll::Cursor.new(cursor, cursor_options)
         # scroll
         if block_given?
@@ -27,6 +27,10 @@ module Mongoid
         else
           criteria
         end
+      end
+
+      def type_from_field(field)
+        field.foreign_key? && field.object_id_field? ? BSON::ObjectId : field.type
       end
     end
   end

--- a/lib/mongoid/scroll/cursor.rb
+++ b/lib/mongoid/scroll/cursor.rb
@@ -14,7 +14,7 @@ module Mongoid
         compare_direction = direction == 1 ? '$gt' : '$lt'
         cursor_criteria = { field_name => { compare_direction => mongo_value } } if mongo_value
         tiebreak_criteria = { field_name => mongo_value, :_id => { compare_direction => tiebreak_id } } if mongo_value && tiebreak_id
-        cursor_selector = if Mongoid::Compatibility::Version.mongoid6?
+        cursor_selector = if Mongoid::Compatibility::Version.mongoid6? || Mongoid::Compatibility::Version.mongoid7?
                             Mongoid::Criteria::Queryable::Selector.new
                           else
                             Origin::Selector.new

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -13,6 +13,7 @@ describe Mongoid::Criteria do
                                                /You're attempting to scroll over data with a sort order that includes multiple fields: name, value./
     end
   end
+
   context 'with no sort' do
     subject do
       Feed::Item.all
@@ -43,6 +44,15 @@ describe Mongoid::Criteria do
         expect(records).to eq Feed::Item.all.to_a
       end
     end
+
+    context 'with a foreign key' do
+      it 'sorts by object id' do
+        records = []
+        Feed::Item.asc('publisher_id').scroll { |r, _| records << r }
+        expect(records).not_to be_empty
+      end
+    end
+
     { a_string: String, a_integer: Integer, a_date: Date, a_datetime: DateTime }.each_pair do |field_name, field_type|
       context field_type do
         it 'scrolls all with a block' do

--- a/spec/support/feed/item.rb
+++ b/spec/support/feed/item.rb
@@ -10,9 +10,10 @@ module Feed
     field :a_time, type: Time
     field :a_array, type: Array
 
-    embeds_many :embedded_items
+    embeds_many :embedded_items, class_name: 'Feed::EmbeddedItem'
 
-    publisher_options = Mongoid::Compatibility::Version.mongoid6? ? { optional: true } : {}
+    publisher_options = { class_name: 'Feed::Publisher' }
+    publisher_options[:optional] = true if Mongoid::Compatibility::Version.mongoid6? || Mongoid::Compatibility::Version.mongoid7?
     belongs_to :publisher, publisher_options
   end
 end

--- a/spec/support/feed/item.rb
+++ b/spec/support/feed/item.rb
@@ -11,5 +11,6 @@ module Feed
     field :a_array, type: Array
 
     embeds_many :embedded_items
+    belongs_to :publisher, optional: true
   end
 end

--- a/spec/support/feed/item.rb
+++ b/spec/support/feed/item.rb
@@ -11,6 +11,8 @@ module Feed
     field :a_array, type: Array
 
     embeds_many :embedded_items
-    belongs_to :publisher, optional: true
+
+    publisher_options = Mongoid::Compatibility::Version.mongoid6? ? { optional: true } : {}
+    belongs_to :publisher, publisher_options
   end
 end

--- a/spec/support/feed/publisher.rb
+++ b/spec/support/feed/publisher.rb
@@ -1,0 +1,9 @@
+module Feed
+  class Publisher
+    include Mongoid::Document
+
+    field :name, type: String
+
+    has_many :items
+  end
+end


### PR DESCRIPTION
@erikdstock and I encountered a problem scrolling by a `..._id` field. This is supported by the driver and database, but fails with `UnsupportedFieldTypeError` like:

    The type of the field 'publisher_id' is not supported: Object.

This is because calling (e.g.) `klass.fields['publisher_id'].type` returns `Object` despite the field actually containing a `BSON::ObjectId`.

Here's our attempt to fix this, but I'm not sure if we're accessing Mongoid's internals in the best manner.