### PR TITLE
Add a cursor to go to the first page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 2.0.0 (Next)
 
-* [#38](https://github.com/mongoid/mongoid-scroll/pull/38): Allow to reverse the scroll - [@GCorbel](https://github.com/GCorbel).
-* [#42](https://github.com/mongoid/mongoid-scroll/pull/42): Add a cursor to go to the first page - [@GCorbel](https://github.com/GCorbel).
+* [#38](https://github.com/mongoid/mongoid-scroll/pull/38): Add `previous_cursor` - [@GCorbel](https://github.com/GCorbel).
+* [#42](https://github.com/mongoid/mongoid-scroll/pull/42): Add `first_cursor` - [@GCorbel](https://github.com/GCorbel).
 * Your contribution here.
 
 ### 1.0.1 (2023/03/15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.0.0 (Next)
 
 * [#38](https://github.com/mongoid/mongoid-scroll/pull/38): Allow to reverse the scroll - [@GCorbel](https://github.com/GCorbel).
+* [#42](https://github.com/mongoid/mongoid-scroll/pull/42): Add a cursor to go to the first page - [@GCorbel](https://github.com/GCorbel).
 * Your contribution here.
 
 ### 1.0.1 (2023/03/15)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Feed::Item.desc(:position).limit(5).scroll(saved_iterator.previous_cursor) do |r
 end
 ```
 
+Use `saved_iterator.first_cursor` to loop over the first records.
+
 The iteration finishes when no more records are available. You can also finish iterating over the remaining records by omitting the query limit.
 
 ```ruby

--- a/lib/mongoid/criteria/scrollable/iterator.rb
+++ b/lib/mongoid/criteria/scrollable/iterator.rb
@@ -8,6 +8,10 @@ module Mongoid
           @previous_cursor = previous_cursor
           @next_cursor = next_cursor
         end
+
+        def first_page_cursor
+          next_cursor.class.new(nil, next_cursor.sort_options)
+        end
       end
     end
   end

--- a/lib/mongoid/criteria/scrollable/iterator.rb
+++ b/lib/mongoid/criteria/scrollable/iterator.rb
@@ -9,7 +9,7 @@ module Mongoid
           @next_cursor = next_cursor
         end
 
-        def first_page_cursor
+        def first_cursor
           next_cursor.class.new(nil, next_cursor.sort_options)
         end
       end

--- a/lib/mongoid/criteria/scrollable/iterator.rb
+++ b/lib/mongoid/criteria/scrollable/iterator.rb
@@ -10,7 +10,7 @@ module Mongoid
         end
 
         def first_cursor
-          next_cursor.class.new(nil, next_cursor.sort_options)
+          @first_cursor ||= next_cursor.class.new(nil, next_cursor.sort_options)
         end
       end
     end

--- a/spec/mongo/collection_view_spec.rb
+++ b/spec/mongo/collection_view_spec.rb
@@ -127,6 +127,17 @@ if Object.const_defined?(:Mongo)
                 expect(Mongoid.default_client['feed_items'].find.sort(field_name => 1).limit(2).scroll(second_iterator.previous_cursor, field_type: field_type).to_a).to eq(records.limit(2).to_a)
                 expect(Mongoid.default_client['feed_items'].find.sort(field_name => 1).limit(2).scroll(third_iterator.previous_cursor, field_type: field_type).to_a).to eq(records.skip(2).limit(2).to_a)
               end
+              it 'can loop over the first records with the first cursor' do
+                first_cursor = nil
+                records = Mongoid.default_client['feed_items'].find.sort(field_name => 1)
+                cursor = cursor_type.from_record records.skip(4).first, field_name: field_name, field_type: field_type, include_current: true
+
+                records.limit(2).scroll(cursor, field_type: field_type) do |_, iterator|
+                  first_cursor = iterator.first_cursor
+                end
+
+                expect(records.limit(2).scroll(first_cursor, field_type: field_type).to_a).to eq(records.limit(2).to_a)
+              end
             end
           end
         end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -181,6 +181,16 @@ describe Mongoid::Criteria do
               expect(Feed::Item.asc(field_name).limit(2).scroll(second_iterator.previous_cursor)).to eq(records.limit(2))
               expect(Feed::Item.asc(field_name).limit(2).scroll(third_iterator.previous_cursor)).to eq(records.skip(2).limit(2))
             end
+            it 'can loop over the first records with the first page cursor' do
+              records = []
+              iterator = nil
+
+              Feed::Item.asc(field_name).limit(2).scroll(cursor_type) do |_, iterator|
+                iterator = iterator
+              end
+
+              expect(Feed::Item.asc(field_name).limit(2).scroll(iterator.first_page_cursor).to_a).to eq(Feed::Item.asc(field_name).limit(2).to_a)
+            end
           end
         end
       end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -182,14 +182,13 @@ describe Mongoid::Criteria do
               expect(Feed::Item.asc(field_name).limit(2).scroll(third_iterator.previous_cursor)).to eq(records.skip(2).limit(2))
             end
             it 'can loop over the first records with the first page cursor' do
-              records = []
-              iterator = nil
+              first_cursor = nil
 
-              Feed::Item.asc(field_name).limit(2).scroll(cursor_type) do |_, iterator|
-                iterator = iterator
+              Feed::Item.asc(field_name).limit(2).scroll(cursor_type) do |_, it|
+                first_cursor = it.first_cursor
               end
 
-              expect(Feed::Item.asc(field_name).limit(2).scroll(iterator.first_page_cursor).to_a).to eq(Feed::Item.asc(field_name).limit(2).to_a)
+              expect(Feed::Item.asc(field_name).limit(2).scroll(first_cursor).to_a).to eq(Feed::Item.asc(field_name).limit(2).to_a)
             end
           end
         end


### PR DESCRIPTION
I added `first_cursor` to Mongoid::Scroll::Scrollable::Iterator.

```
first_cursor = nil

cursor = cursor_type.from_record Feed::Item.last, field_name: field_name, field_type: field_type

Feed::Item.asc(field_name).limit(2).scroll(cursor) do |_, iterator|
  first_cursor = iterator.first_cursor
end

Feed::Item.asc(field_name).limit(2).scroll(first_cursor) do |record|
  # loop over the 2 first records.
end
```

This is honestly kind of the same than `Feed::Item.asc(field_name).limit(2)` but allows to keep sort options encrypted the same way it is for other kind of cursors.

We use it to have this kind of payload for an API response : 

```
GET {{baseUrl}}/attachments?pageToken=eyJ2YWx1ZSI6bnVsbCwiZmllbGRfdHlwZSI6IlRpbWUiLCJmaWVsZF9uYW1lIjoiY3JlYXRlZF9hdCIsImRpcmVjdGlvbiI6MSwiaW5jbHVkZV9jdXJyZW50IjpmYWxzZSwidGllYnJlYWtfaWQiOm51bGwsInR5cGUiOiJuZXh0In0=
{
    "records": [
        // ....
    ],
    "paging": {
        "pageToken": "eyJ2YWx1ZSI6MTM0OTM2MTI4MS4wMjcsImZpZWxkX3R5cGUiOiJUaW1lIiwiZmllbGRfbmFtZSI6ImNyZWF0ZWRfYXQiLCJkaXJlY3Rpb24iOjEsImluY2x1ZGVfY3VycmVudCI6dHJ1ZSwidGllYnJlYWtfaWQiOiI1MDZkOWU4MTdhYTU4ZDEyNTkwMDBmMTIiLCJ0eXBlIjoibmV4dCJ9",
        "perPage": 1,
        "firstPageToken": "eyJ2YWx1ZSI6bnVsbCwiZmllbGRfdHlwZSI6IlRpbWUiLCJmaWVsZF9uYW1lIjoiY3JlYXRlZF9hdCIsImRpcmVjdGlvbiI6MSwiaW5jbHVkZV9jdXJyZW50IjpmYWxzZSwidGllYnJlYWtfaWQiOm51bGwsInR5cGUiOiJuZXh0In0=",
        "nextPageToken": "eyJ2YWx1ZSI6MTM0OTM2MTI4MS4wMjcsImZpZWxkX3R5cGUiOiJUaW1lIiwiZmllbGRfbmFtZSI6ImNyZWF0ZWRfYXQiLCJkaXJlY3Rpb24iOjEsImluY2x1ZGVfY3VycmVudCI6ZmFsc2UsInRpZWJyZWFrX2lkIjoiNTA2ZDllODE3YWE1OGQxMjU5MDAwZjEyIiwidHlwZSI6Im5leHQifQ=="
    }
}
```

Given that, we can go to the first page at any time.