### PR TITLE
Add a cursor for the current page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 2.0.0 (Next)
 
 * [#38](https://github.com/mongoid/mongoid-scroll/pull/38): Allow to reverse the scroll - [@GCorbel](https://github.com/GCorbel).
-* [#43](https://github.com/mongoid/mongoid-scroll/pull/43): Add a cursor to go to the current page - [@GCorbel](https://github.com/GCorbel).
+* [#43](https://github.com/mongoid/mongoid-scroll/pull/43): Add a current cursor - [@GCorbel](https://github.com/GCorbel).
 * Your contribution here.
 
 ### 1.0.1 (2023/03/15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 2.0.0 (Next)
 
 * [#38](https://github.com/mongoid/mongoid-scroll/pull/38): Allow to reverse the scroll - [@GCorbel](https://github.com/GCorbel).
-* [#43](https://github.com/mongoid/mongoid-scroll/pull/43): Add a cursor to go to the first page - [@GCorbel](https://github.com/GCorbel).
+* [#43](https://github.com/mongoid/mongoid-scroll/pull/43): Add a cursor to go to the current page - [@GCorbel](https://github.com/GCorbel).
 * Your contribution here.
 
 ### 1.0.1 (2023/03/15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.0.0 (Next)
 
 * [#38](https://github.com/mongoid/mongoid-scroll/pull/38): Allow to reverse the scroll - [@GCorbel](https://github.com/GCorbel).
+* [#43](https://github.com/mongoid/mongoid-scroll/pull/43): Add a cursor to go to the first page - [@GCorbel](https://github.com/GCorbel).
 * Your contribution here.
 
 ### 1.0.1 (2023/03/15)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Feed::Item.desc(:position).limit(5).scroll(saved_iterator.previous_cursor) do |r
 end
 ```
 
-`saved_iterator.current_cursor` can be used to loop over the same records again.
+Use `saved_iterator.current_cursor` to loop over the same records again.
 
 The iteration finishes when no more records are available. You can also finish iterating over the remaining records by omitting the query limit.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Feed::Item.desc(:position).limit(5).scroll(saved_iterator.previous_cursor) do |r
 end
 ```
 
+`saved_iterator.current_cursor` can be used to loop over the same records again.
+
 The iteration finishes when no more records are available. You can also finish iterating over the remaining records by omitting the query limit.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -161,14 +161,7 @@ end
 
 ## Cursors
 
-You can use `Mongoid::Scroll::Cursor.from_record` to generate a cursor. A cursor points at the last record of the 
-
-
-
-
-
-
-iteration and unlike MongoDB cursors will not expire.
+You can use `Mongoid::Scroll::Cursor.from_record` to generate a cursor. A cursor points at the last record of the iteration and unlike MongoDB cursors will not expire.
 
 ```ruby
 record = Feed::Item.desc(:position).limit(3).last

--- a/lib/mongo/scrollable.rb
+++ b/lib/mongo/scrollable.rb
@@ -41,11 +41,14 @@ module Mongo
       # scroll
       if block_given?
         previous_cursor = nil
+        current_cursor = nil
         records.each do |record|
           previous_cursor ||= cursor_type.from_record(record, cursor_options.merge(type: :previous))
+          current_cursor ||= cursor_type.from_record(record, cursor_options.merge(include_current: true))
           iterator = Mongoid::Criteria::Scrollable::Iterator.new(
             previous_cursor: previous_cursor,
-            next_cursor: cursor_type.from_record(record, cursor_options)
+            next_cursor: cursor_type.from_record(record, cursor_options),
+              current_cursor: current_cursor
           )
           yield record, iterator
         end

--- a/lib/mongo/scrollable.rb
+++ b/lib/mongo/scrollable.rb
@@ -48,7 +48,7 @@ module Mongo
           iterator = Mongoid::Criteria::Scrollable::Iterator.new(
             previous_cursor: previous_cursor,
             next_cursor: cursor_type.from_record(record, cursor_options),
-              current_cursor: current_cursor
+            current_cursor: current_cursor
           )
           yield record, iterator
         end

--- a/lib/mongoid/criteria/scrollable.rb
+++ b/lib/mongoid/criteria/scrollable.rb
@@ -15,11 +15,14 @@ module Mongoid
         records = find_records(criteria, cursor)
         if block_given?
           previous_cursor = nil
+          current_cursor = nil
           records.each do |record|
             previous_cursor ||= cursor_from_record(cursor_type, record, cursor_options.merge(type: :previous))
+            current_cursor ||= cursor_from_record(cursor_type, record, cursor_options.merge(include_current: true))
             iterator = Mongoid::Criteria::Scrollable::Iterator.new(
               previous_cursor: previous_cursor,
-              next_cursor: cursor_from_record(cursor_type, record, cursor_options)
+              next_cursor: cursor_from_record(cursor_type, record, cursor_options),
+              current_cursor: current_cursor
             )
             yield record, iterator
           end

--- a/lib/mongoid/criteria/scrollable/iterator.rb
+++ b/lib/mongoid/criteria/scrollable/iterator.rb
@@ -2,10 +2,11 @@ module Mongoid
   class Criteria
     module Scrollable
       class Iterator
-        attr_accessor :previous_cursor, :next_cursor
+        attr_accessor :previous_cursor, :current_cursor, :next_cursor
 
-        def initialize(previous_cursor:, next_cursor:)
+        def initialize(previous_cursor:, current_cursor:, next_cursor:)
           @previous_cursor = previous_cursor
+          @current_cursor = current_cursor
           @next_cursor = next_cursor
         end
       end

--- a/spec/mongo/collection_view_spec.rb
+++ b/spec/mongo/collection_view_spec.rb
@@ -127,6 +127,17 @@ if Object.const_defined?(:Mongo)
                 expect(Mongoid.default_client['feed_items'].find.sort(field_name => 1).limit(2).scroll(second_iterator.previous_cursor, field_type: field_type).to_a).to eq(records.limit(2).to_a)
                 expect(Mongoid.default_client['feed_items'].find.sort(field_name => 1).limit(2).scroll(third_iterator.previous_cursor, field_type: field_type).to_a).to eq(records.skip(2).limit(2).to_a)
               end
+              it 'can loop over the same records with the current cursor' do
+                current_cursor = nil
+                records = Mongoid.default_client['feed_items'].find.sort(field_name => 1)
+                cursor = cursor_type.from_record records.skip(4).first, field_name: field_name, field_type: field_type, include_current: true
+
+                records.limit(2).scroll(cursor, field_type: field_type) do |record, iterator|
+                  current_cursor = iterator.current_cursor
+                end
+
+                expect(records.limit(2).scroll(current_cursor, field_type: field_type).to_a).to eq(records.skip(4).limit(2).to_a)
+              end
             end
           end
         end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -181,11 +181,11 @@ describe Mongoid::Criteria do
               expect(Feed::Item.asc(field_name).limit(2).scroll(second_iterator.previous_cursor)).to eq(records.limit(2))
               expect(Feed::Item.asc(field_name).limit(2).scroll(third_iterator.previous_cursor)).to eq(records.skip(2).limit(2))
             end
-            it 'can loop over the first records with the first page cursor' do
+            it 'can loop over the same records with the current cursor' do
               current_cursor = nil
               cursor = cursor_type.from_record Feed::Item.find_by(name: '7'), field_name: field_name, field_type: field_type
 
-              Feed::Item.asc(field_name).limit(2).scroll(cursor) do |record, iterator|
+              Feed::Item.asc(field_name).limit(2).scroll(cursor) do |_, iterator|
                 current_cursor = iterator.current_cursor
               end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -181,6 +181,16 @@ describe Mongoid::Criteria do
               expect(Feed::Item.asc(field_name).limit(2).scroll(second_iterator.previous_cursor)).to eq(records.limit(2))
               expect(Feed::Item.asc(field_name).limit(2).scroll(third_iterator.previous_cursor)).to eq(records.skip(2).limit(2))
             end
+            it 'can loop over the first records with the first page cursor' do
+              current_cursor = nil
+              cursor = cursor_type.from_record Feed::Item.find_by(name: '7'), field_name: field_name, field_type: field_type
+
+              Feed::Item.asc(field_name).limit(2).scroll(cursor) do |record, iterator|
+                current_cursor = iterator.current_cursor
+              end
+
+              expect(Feed::Item.asc(field_name).limit(2).scroll(current_cursor).to_a).to eq(Feed::Item.asc(field_name).last(2))
+            end
           end
         end
       end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -183,13 +183,13 @@ describe Mongoid::Criteria do
             end
             it 'can loop over the same records with the current cursor' do
               current_cursor = nil
-              cursor = cursor_type.from_record Feed::Item.find_by(name: '7'), field_name: field_name, field_type: field_type
+              cursor = cursor_type.from_record Feed::Item.skip(4).first, field_name: field_name, field_type: field_type, include_current: true
 
               Feed::Item.asc(field_name).limit(2).scroll(cursor) do |_, iterator|
                 current_cursor = iterator.current_cursor
               end
 
-              expect(Feed::Item.asc(field_name).limit(2).scroll(current_cursor).to_a).to eq(Feed::Item.asc(field_name).last(2))
+              expect(Feed::Item.asc(field_name).limit(2).scroll(current_cursor).to_a).to eq(Feed::Item.asc(field_name).skip(4).limit(2).to_a)
             end
           end
         end


### PR DESCRIPTION
I added `current_cursor` to `Mongoid::Scroll::Scrollable::Iterator`.

```
current_cursor = nil

cursor = cursor_type.from_record Feed::Item.find_by(name: '7'), field_name: field_name, field_type: field_type

Feed::Item.asc(field_name).limit(2).scroll(cursor) do |_, iterator|
  current_cursor = iterator.current_cursor
end

Feed::Item.asc(field_name).limit(2).scroll(current_cursor) do |record|
  # loop over the same records
end
```

This allows to store the cursor and have the same result.

We use it to have this kind of payload for an API response :

```
GET {{baseUrl}}/attachments?pageToken=eyJ2YWx1ZSI6bnVsbCwiZmllbGRfdHlwZSI6IlRpbWUiLCJmaWVsZF9uYW1lIjoiY3JlYXRlZF9hdCIsImRpcmVjdGlvbiI6MSwiaW5jbHVkZV9jdXJyZW50IjpmYWxzZSwidGllYnJlYWtfaWQiOm51bGwsInR5cGUiOiJuZXh0In0=
{
    "records": [
        // ....
    ],
    "paging": {
        "pageToken": "eyJ2YWx1ZSI6MTM0OTM2MTI4MS4wMjcsImZpZWxkX3R5cGUiOiJUaW1lIiwiZmllbGRfbmFtZSI6ImNyZWF0ZWRfYXQiLCJkaXJlY3Rpb24iOjEsImluY2x1ZGVfY3VycmVudCI6dHJ1ZSwidGllYnJlYWtfaWQiOiI1MDZkOWU4MTdhYTU4ZDEyNTkwMDBmMTIiLCJ0eXBlIjoibmV4dCJ9",
        "perPage": 1,
        "firstPageToken": "eyJ2YWx1ZSI6bnVsbCwiZmllbGRfdHlwZSI6IlRpbWUiLCJmaWVsZF9uYW1lIjoiY3JlYXRlZF9hdCIsImRpcmVjdGlvbiI6MSwiaW5jbHVkZV9jdXJyZW50IjpmYWxzZSwidGllYnJlYWtfaWQiOm51bGwsInR5cGUiOiJuZXh0In0=",
        "nextPageToken": "eyJ2YWx1ZSI6MTM0OTM2MTI4MS4wMjcsImZpZWxkX3R5cGUiOiJUaW1lIiwiZmllbGRfbmFtZSI6ImNyZWF0ZWRfYXQiLCJkaXJlY3Rpb24iOjEsImluY2x1ZGVfY3VycmVudCI6ZmFsc2UsInRpZWJyZWFrX2lkIjoiNTA2ZDllODE3YWE1OGQxMjU5MDAwZjEyIiwidHlwZSI6Im5leHQifQ=="
    }
}
```

Given that, we can find the same records if we do a call with the token related to the current cursor.