### PR TITLE
Migrate Danger to danger-pr-comment workflow

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -1,0 +1,9 @@
+name: Danger Comment
+on:
+  workflow_run:
+    workflows: [Danger]
+    types: [completed]
+jobs:
+  comment:
+    uses: numbata/danger-pr-comment/.github/workflows/comment.yml@v0.1.0
+    secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,17 +1,11 @@
-name: PR Linter
-on: [pull_request]
+name: Danger
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
 jobs:
   danger:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-          bundler-cache: true
-      - run: |
-          # Personal access token for dangerpr-bot - public, but base64 encoded to avoid tripping up GitHub
-          TOKEN=$(echo -n Z2hwX0xNQ3VmanBFeTBvYkZVTWh6NVNqVFFBOEUxU25abzBqRUVuaAo= | base64 --decode)
-          DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose
+    uses: numbata/danger-pr-comment/.github/workflows/danger.yml@v0.1.0
+    with:
+      ruby-version: '3.0'
+      bundler-cache: true
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.0.1 (Next)
 
+* [#49](https://github.com/mongoid/mongoid-scroll/pull/49): Migrate Danger to danger-pr-comment workflow - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 2.0.0 (2024/09/07)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,1 +1,5 @@
-danger.import_dangerfile(gem: 'mongoid-danger')
+# frozen_string_literal: true
+
+danger.import_plugin('danger-pr-comment')
+
+changelog.check!

--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,11 @@ end
 group :development, :test do
   gem 'bundler'
   gem 'coveralls_reborn', require: false
+  gem 'danger', require: false
+  gem 'danger-changelog', require: false
+  gem 'danger-pr-comment', require: false
   gem 'database_cleaner', '~> 1.8.5'
   gem 'faker'
-  gem 'mongoid-danger', '~> 0.2.0', require: false
   gem 'rake'
   gem 'rspec', '~> 3.0'
   gem 'rspec-its'


### PR DESCRIPTION
## Summary
- Migrates from mongoid-danger to the danger-pr-comment workflow pattern
- Adds danger, danger-changelog, and danger-pr-comment gems to Gemfile
- Updates Dangerfile to use danger-pr-comment plugin and changelog.check!
- Replaces custom Danger workflow with reusable workflows from numbata/danger-pr-comment

## Changes
- Updated `.github/workflows/danger.yml` to use reusable workflow
- Added `.github/workflows/danger-comment.yml` for PR commenting
- Removed `mongoid-danger` dependency from Gemfile
- Updated Dangerfile to import danger-pr-comment and perform changelog checks

## Test plan
- [x] Verify Danger workflow runs on PR
- [x] Verify PR comments are posted correctly
- [x] Verify changelog validation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)